### PR TITLE
Solve "Cannot find module 'MailParser'" issue

### DIFF
--- a/smtp.js
+++ b/smtp.js
@@ -1,5 +1,5 @@
 var simplesmtp = require('simplesmtp');
-var MailParser = require('MailParser').MailParser;
+var MailParser = require('mailparser').MailParser;
 var storage = require('./lib/storage');
 
 var port = process.env.SMTP_PORT || 2525;


### PR DESCRIPTION
The app was launching the error "Cannot find module 'MailParser'" when I tried to start it. This solved it.
