### PR TITLE
Add config for packager.io

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,0 +1,9 @@
+default_dependencies: false
+targets:
+  ubuntu-12.04:
+  ubuntu-14.04:
+  debian-8:
+  debian-7:
+before:
+  - mv packager/Procfile .
+after_install: ./packager/postinst

--- a/packager/Procfile
+++ b/packager/Procfile
@@ -1,0 +1,1 @@
+main: node bin/mail-null

--- a/packager/postinst
+++ b/packager/postinst
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+APP_NAME="mail-null"
+CLI="$APP_NAME"
+
+$CLI scale main=0 || true
+$CLI scale main=1 || true

--- a/smtp.js
+++ b/smtp.js
@@ -5,7 +5,7 @@ var storage = require('./lib/storage');
 var port = process.env.SMTP_PORT || 2525;
 
 simplesmtp.createSimpleServer(
-	{SMTPBanner: '/mail/null - where your test emails go to die'},
+	{disableSTARTTLS: true, ignoreTLS: true, SMTPBanner: '/mail/null - where your test emails go to die'},
 	function (req) {
 		var mailparser = new MailParser();
 		mailparser.on('end', function (email) {


### PR DESCRIPTION
You can now install mail null as debian package.

https://packager.io/gh/nodelogstashpackager/mail-null