### PR TITLE
Fix sidebar taking too much space

### DIFF
--- a/public/stylesheets/style.styl
+++ b/public/stylesheets/style.styl
@@ -43,6 +43,7 @@ button.warn
 .sidebar
   display: table-cell
   width: sidebar-width
+  max-width: sidebar-width
 
 .sidebar ul
   list-style-type: none


### PR DESCRIPTION
On smaller screens the sidebar takes the whole part of the page, let's focus on the email instead :)